### PR TITLE
Fix Modal div className

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-hoc",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "React HOCs",
   "main": "lib/index.js",
   "repository": "launchpadlab/lp-hoc",

--- a/src/modal.js
+++ b/src/modal.js
@@ -70,7 +70,7 @@ function modal ({
       return (
         <div className={ classnames('modal', { 'modal-warning': warning, 'is-active': props.show })}>
           <div className="modal-fade-screen" onClick={ disableOutsideClick ? noop : props.handleHide }>
-            <div className="modal-content">
+            <div className="modal-inner">
               <WrappedComponent { ...props } /> 
             </div>
           </div>


### PR DESCRIPTION
Wrong class name on inner `div` of `modal` causing issues with our current `modal.scss` styles in the client template:
<img width="1440" alt="screen shot 2018-02-14 at 2 53 41 pm" src="https://user-images.githubusercontent.com/7934550/36227562-01f5d816-1197-11e8-842d-72c940f86915.png">
