### PR TITLE
Require `name` prop in `modal`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-hoc",
-  "version": "2.9.0",
+  "version": "3.0.0",
   "description": "React HOCs",
   "main": "lib/index.js",
   "repository": "launchpadlab/lp-hoc",

--- a/src/modal.js
+++ b/src/modal.js
@@ -84,6 +84,8 @@ function modal ({
       name,
       ...options,
     })(ModalWrapper)
+    // Rename the whole thing to the modal name so we can call actions on it
+    connectedModalWrapper.displayName = name
     // Attach action creators to component
     connectedModalWrapper.show = (props) => show(name, props)
     connectedModalWrapper.hide = () => hide(name)

--- a/src/modal.js
+++ b/src/modal.js
@@ -84,8 +84,6 @@ function modal ({
       name,
       ...options,
     })(ModalWrapper)
-    // Rename the whole thing to the modal name so we can call actions on it
-    connectedModalWrapper.displayName = name
     // Attach action creators to component
     connectedModalWrapper.show = (props) => show(name, props)
     connectedModalWrapper.hide = () => hide(name)

--- a/src/modal.js
+++ b/src/modal.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { connectModal, show, hide, destroy } from 'redux-modal'
 import classnames from 'classnames'
 import BodyClassName from 'react-body-classname'
-import { getDisplayName, noop } from './utils'
+import { noop } from './utils'
 
 /**
  * A function that returns a React HOC for creating modals.
@@ -64,8 +64,7 @@ function modal ({
   ...options 
 } = {}) {
   return WrappedComponent => {
-    const modalName = name || getDisplayName(WrappedComponent)
-    if (!modalName) throw new Error('Must provide name option or wrap a named component')
+    if (!name) throw new Error('Must provide name option')
     /* eslint react/prop-types: 0 */
     function ModalWrapper (props) {
       return (
@@ -82,15 +81,13 @@ function modal ({
     }
 
     const connectedModalWrapper = connectModal({
-      name: modalName,
+      name,
       ...options,
     })(ModalWrapper)
-    // Rename the whole thing to the modal name so we can call actions on it`
-    connectedModalWrapper.displayName = modalName
     // Attach action creators to component
-    connectedModalWrapper.show = (props) => show(modalName, props)
-    connectedModalWrapper.hide = () => hide(modalName)
-    connectedModalWrapper.destroy = () => destroy(modalName)
+    connectedModalWrapper.show = (props) => show(name, props)
+    connectedModalWrapper.hide = () => hide(name)
+    connectedModalWrapper.destroy = () => destroy(name)
     return connectedModalWrapper
   }
 }

--- a/test/modal.test.js
+++ b/test/modal.test.js
@@ -9,7 +9,7 @@ test('modal has correct displayName', () => {
 
 test('modal exposes the `show` function', () => {
   const Wrapped = () => <h1>Hi</h1>
-  const Wrapper = modal()(Wrapped)
+  const Wrapper = modal({ name: 'TestModal' })(Wrapped)
   const spy = jest.spyOn(Wrapper, 'show')
   const showResponse = Wrapper.show()
   expect(spy).toHaveBeenCalled()
@@ -18,7 +18,7 @@ test('modal exposes the `show` function', () => {
 
 test('modal exposes the `hide` function', () => {
   const Wrapped = () => <h1>Hi</h1>
-  const Wrapper = modal()(Wrapped)
+  const Wrapper = modal({ name: 'TestModal' })(Wrapped)
   const spy = jest.spyOn(Wrapper, 'hide')
   const hideResponse = Wrapper.hide()
   expect(spy).toHaveBeenCalled()
@@ -27,9 +27,14 @@ test('modal exposes the `hide` function', () => {
 
 test('modal exposes the `destroy` function', () => {
   const Wrapped = () => <h1>Hi</h1>
-  const Wrapper = modal()(Wrapped)
+  const Wrapper = modal({ name: 'TestModal' })(Wrapped)
   const spy = jest.spyOn(Wrapper, 'destroy')
   const destroyResponse = Wrapper.destroy()
   expect(spy).toHaveBeenCalled()
   expect(destroyResponse.type).toEqual('@redux-modal/DESTROY')
+})
+
+test('modal throws an error when `name` prop is missing', () => {
+  const Wrapped = () => <h1>Hi</h1>
+  expect(() => modal()(Wrapped)).toThrow()
 })

--- a/test/modal.test.js
+++ b/test/modal.test.js
@@ -1,12 +1,6 @@
 import React from 'react'
 import { modal } from '../src/'
 
-test('modal has correct displayName', () => {
-  const Wrapped = () => <h1>Alert!</h1>
-  const Wrapper = modal({ name: 'AlertModal' })(Wrapped)
-  expect(Wrapper.displayName).toEqual('AlertModal')
-})
-
 test('modal exposes the `show` function', () => {
   const Wrapped = () => <h1>Hi</h1>
   const Wrapper = modal({ name: 'TestModal' })(Wrapped)


### PR DESCRIPTION
Resolves #37 

Keeping `displayName` for development, but requiring `name` 