### PR TITLE
Bump lp-requests to 3.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-hoc",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "React HOCs",
   "main": "lib/index.js",
   "repository": "launchpadlab/lp-hoc",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@launchpadlab/lp-components": "^3.11.3",
-    "@launchpadlab/lp-requests": "^3.0.0",
+    "@launchpadlab/lp-requests": "^3.5.1",
     "classnames": "^2.2.5",
     "humps": "^2.0.1",
     "lodash": "^4.17.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,11 +1022,12 @@
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.4"
 
-"@launchpadlab/lp-requests@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@launchpadlab/lp-requests/-/lp-requests-3.0.0.tgz#01582fb4b9a32b0996cb97c090877a1606b90722"
-  integrity sha1-AVgvtLmjKwmWy5fAkId6Fga5ByI=
+"@launchpadlab/lp-requests@^3.0.0", "@launchpadlab/lp-requests@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@launchpadlab/lp-requests/-/lp-requests-3.5.1.tgz#ec035b5d2450577955c1e489768d68d9009251ed"
+  integrity sha512-wstxJk2h6IgzQBKWl/qy6QBiw/DtnrF2anS4kddi2/inOG98Inf+OeJSw9Kg0xx7qCW6Fd18XnW4v+Rz0KCE6A==
   dependencies:
+    Base64 "^1.0.1"
     babel-preset-react "^6.24.1"
     humps "^2.0.0"
     is-promise "^2.1.0"
@@ -1034,7 +1035,7 @@
     js-cookie "^2.1.4"
     lodash "^4.17.4"
     query-string "^5.0.0"
-    url-join "^2.0.2"
+    url-join "^4.0.0"
 
 "@types/events@*":
   version "1.1.0"
@@ -1047,6 +1048,11 @@
   integrity sha512-qetMdTv3Ytz9u9ESLdcYs45LPI0mczYZIbC184n7kY0jczOqPNQsabBfVCh+na3B2shAfvC459JqHV771A8Rxg==
   dependencies:
     "@types/events" "*"
+
+Base64@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/Base64/-/Base64-1.0.1.tgz#def45cc50c961bcc9bf2321d0f52bcbfec1f1bb1"
+  integrity sha1-3vRcxQyWG8yb8jIdD1K8v+wfG7E=
 
 JSONStream@^1.0.3:
   version "1.3.1"
@@ -3002,7 +3008,12 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.4.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.1.tgz#87416ae817de957a3f249b3b5ca475d4aaed6042"
+  integrity sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg==
+
+core-js@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
   integrity sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=
@@ -5765,9 +5776,9 @@ jest@^23.6.0:
     jest-cli "^23.6.0"
 
 js-cookie@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.1.4.tgz#da4ec503866f149d164cf25f579ef31015025d8d"
-  integrity sha1-2k7FA4ZvFJ0WTPJfV57zEBUCXY0=
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
+  integrity sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s=
 
 js-levenshtein@^1.1.3:
   version "1.1.4"
@@ -7334,16 +7345,7 @@ query-string@^4.2.2:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.0.0.tgz#fbdf7004b4d2aff792f9871981b7a2794f555947"
-  integrity sha1-+99wBLTSr/eS+YcZgbeieU9VWUc=
-  dependencies:
-    decode-uri-component "^0.2.0"
-    object-assign "^4.1.0"
-    strict-uri-encode "^1.0.0"
-
-query-string@^5.1.1:
+query-string@^5.0.0, query-string@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
   integrity sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==
@@ -7763,9 +7765,9 @@ regenerator-runtime@^0.10.5:
   integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
 
 regenerator-runtime@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
-  integrity sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -9147,10 +9149,10 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-join@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/url-join/-/url-join-2.0.2.tgz#c072756967ad24b8b59e5741551caac78f50b8b7"
-  integrity sha1-wHJ1aWetJLi1nldBVRyqx49QuLc=
+url-join@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.0.tgz#4d3340e807d3773bda9991f8305acdcc2a665d2a"
+  integrity sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
Main reason is to make sure we use query-string@5, which is compatible with all browsers.