### PR TITLE
Add enhanced logic for sanitizing and replacing file name

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -12,62 +12,64 @@
 -   [cloudinaryUploader][8]
     -   [Parameters][9]
     -   [Examples][10]
--   [deprecate][11]
+-   [defaultCreatePublicId][11]
     -   [Parameters][12]
-    -   [Examples][13]
--   [getSet][14]
-    -   [Parameters][15]
-    -   [Examples][16]
--   [getSetPropTypes][17]
-    -   [Parameters][18]
-    -   [Examples][19]
--   [modal][20]
-    -   [Parameters][21]
-    -   [Examples][22]
--   [modifyProps][23]
-    -   [Parameters][24]
-    -   [Examples][25]
--   [omitProps][26]
-    -   [Parameters][27]
-    -   [Examples][28]
--   [withClassName][29]
-    -   [Parameters][30]
-    -   [Examples][31]
--   [onError][32]
-    -   [Parameters][33]
-    -   [Examples][34]
--   [onMount][35]
-    -   [Parameters][36]
-    -   [Examples][37]
--   [onOutsideClick][38]
-    -   [Parameters][39]
-    -   [Examples][40]
--   [onUnmount][41]
-    -   [Parameters][42]
-    -   [Examples][43]
--   [onUpdate][44]
-    -   [Parameters][45]
-    -   [Examples][46]
--   [sortable][47]
-    -   [Parameters][48]
-    -   [Examples][49]
--   [sortablePropTypes][50]
+-   [deprecate][13]
+    -   [Parameters][14]
+    -   [Examples][15]
+-   [getSet][16]
+    -   [Parameters][17]
+    -   [Examples][18]
+-   [getSetPropTypes][19]
+    -   [Parameters][20]
+    -   [Examples][21]
+-   [modal][22]
+    -   [Parameters][23]
+    -   [Examples][24]
+-   [modifyProps][25]
+    -   [Parameters][26]
+    -   [Examples][27]
+-   [omitProps][28]
+    -   [Parameters][29]
+    -   [Examples][30]
+-   [withClassName][31]
+    -   [Parameters][32]
+    -   [Examples][33]
+-   [onError][34]
+    -   [Parameters][35]
+    -   [Examples][36]
+-   [onMount][37]
+    -   [Parameters][38]
+    -   [Examples][39]
+-   [onOutsideClick][40]
+    -   [Parameters][41]
+    -   [Examples][42]
+-   [onUnmount][43]
+    -   [Parameters][44]
+    -   [Examples][45]
+-   [onUpdate][46]
+    -   [Parameters][47]
+    -   [Examples][48]
+-   [sortable][49]
+    -   [Parameters][50]
     -   [Examples][51]
--   [toggle][52]
-    -   [Parameters][53]
-    -   [Examples][54]
--   [togglePropTypes][55]
-    -   [Parameters][56]
-    -   [Examples][57]
--   [waitFor][58]
-    -   [Parameters][59]
-    -   [Examples][60]
--   [connectQuery][61]
-    -   [Parameters][62]
-    -   [Examples][63]
--   [connectParams][64]
-    -   [Parameters][65]
-    -   [Examples][66]
+-   [sortablePropTypes][52]
+    -   [Examples][53]
+-   [toggle][54]
+    -   [Parameters][55]
+    -   [Examples][56]
+-   [togglePropTypes][57]
+    -   [Parameters][58]
+    -   [Examples][59]
+-   [waitFor][60]
+    -   [Parameters][61]
+    -   [Examples][62]
+-   [connectQuery][63]
+    -   [Parameters][64]
+    -   [Examples][65]
+-   [connectParams][66]
+    -   [Parameters][67]
+    -   [Examples][68]
 
 ## adaptToReactRouter
 
@@ -75,7 +77,7 @@ This HOC allows the creation of custom `react-router` route components.
 It can be used to wrap any component that returns a `<Route />` tag, and will allow that component to be used interchangeably with `<Route />`.
 Note: only compatible with `react-router` v3.
 
-This rationale for this HOC can be found [here][67].
+This rationale for this HOC can be found [here][69].
 
 ### Examples
 
@@ -124,11 +126,11 @@ function MyForm ({ handleSubmit }) {
 ## camelizeProps
 
 A function that returns a React HOC that converts a component's props into camel-case.
-This HOC is particularly useful in conjunction with [react_on_rails][68].
+This HOC is particularly useful in conjunction with [react_on_rails][70].
 
 ### Parameters
 
--   `propName` **([String][69] \| [Array][70])** The name(s) of the prop(s) to camelize. If no argument is provided, all props will be camelized.
+-   `propName` **([String][71] \| [Array][72])** The name(s) of the prop(s) to camelize. If no argument is provided, all props will be camelized.
 
 ### Examples
 
@@ -149,7 +151,7 @@ export default compose(
 // Now we can pass props { full_name, profile_pic } to the above component.
 ```
 
-Returns **[Function][71]** A HOC that can be used to wrap a component.
+Returns **[Function][73]** A HOC that can be used to wrap a component.
 
 ## cloudinaryUploader
 
@@ -162,14 +164,14 @@ A function that returns a React HOC for uploading files to (Cloudinary)[https://
 
 ### Parameters
 
--   `cloudName` **[string][69]** The name of the Cloudinary cloud to upload to. Can also be set via `CLOUDINARY_CLOUD_NAME` in `process.env`.
--   `bucket` **[string][69]** The name of the Cloudinary bucket to upload to. Can also be set via `CLOUDINARY_BUCKET` in `process.env`.
--   `uploadPreset` **[string][69]** The name of the Cloudinary upload preset. Can also be set via `CLOUDINARY_UPLOAD_PRESET` in `process.env`. (optional, default `default`)
--   `endpoint` **[string][69]** The endpoint for the upload request. Can also be set via `CLOUDINARY_ENDPOINT` in `process.env`. (optional, default `https://api.cloudinary.com/v1_1/`)
--   `fileType` **[string][69]** The type of file. (optional, default `auto`)
--   `cloudinaryPublicId` **[string][69]?** The name of the file stored in Cloudinary.
--   `createPublicId` **[string][69]?** A function to generate a custom public id for the uploaded file. This function is passed the file object and is expected to return a string. Overridden by the `cloudinaryPublicId` prop.
--   `requestOptions` **[object][72]** Options for the request, as specified by (`lp-requests`)[https://github.com/LaunchPadLab/lp-requests/blob/master/src/http/http.js]. (optional, default `DEFAULT_REQUEST_OPTIONS`)
+-   `cloudName` **[string][71]** The name of the Cloudinary cloud to upload to. Can also be set via `CLOUDINARY_CLOUD_NAME` in `process.env`.
+-   `bucket` **[string][71]** The name of the Cloudinary bucket to upload to. Can also be set via `CLOUDINARY_BUCKET` in `process.env`.
+-   `uploadPreset` **[string][71]** The name of the Cloudinary upload preset. Can also be set via `CLOUDINARY_UPLOAD_PRESET` in `process.env`. (optional, default `default`)
+-   `endpoint` **[string][71]** The endpoint for the upload request. Can also be set via `CLOUDINARY_ENDPOINT` in `process.env`. (optional, default `https://api.cloudinary.com/v1_1/`)
+-   `fileType` **[string][71]** The type of file. (optional, default `auto`)
+-   `cloudinaryPublicId` **[string][71]?** The name of the file stored in Cloudinary.
+-   `createPublicId` **[string][71]?** A function to generate a custom public id for the uploaded file. This function is passed the file object and is expected to return a string. Overridden by the `cloudinaryPublicId` prop.
+-   `requestOptions` **[object][74]** Options for the request, as specified by (`lp-requests`)[https://github.com/LaunchPadLab/lp-requests/blob/master/src/http/http.js]. (optional, default `DEFAULT_REQUEST_OPTIONS`)
 
 ### Examples
 
@@ -201,7 +203,20 @@ export default compose(
 )(CloudinaryFileInput)
 ```
 
-Returns **[Function][71]** A HOC that can be used to wrap a component.
+Returns **[Function][73]** A HOC that can be used to wrap a component.
+
+## defaultCreatePublicId
+
+The default public id creator returns the sanitized name of the file by
+replacing invalid characters (incl. those that may be html escaped).
+Cloudinary does _not_ handle html escaping well via the API our their
+dashboard so it's best to avoid it entirely.
+
+Source: [https://support.cloudinary.com/hc/en-us/articles/115001317409--Legal-naming-conventions][75]
+
+### Parameters
+
+-   `file`  
 
 ## deprecate
 
@@ -213,8 +228,8 @@ If no message is provided, the default deprecation message is:
 
 ### Parameters
 
--   `message` **[String][69]?** A custom message to display
--   `log` **[Function][71]** A function for logging the message (optional, default `console.warn`)
+-   `message` **[String][71]?** A custom message to display
+-   `log` **[Function][73]** A function for logging the message (optional, default `console.warn`)
 
 ### Examples
 
@@ -245,8 +260,8 @@ These options can also be passed in as props to the wrapped component.
 
 ### Parameters
 
--   `varNames` **([string][69] \| [Array][70])** A variable name or array of variable names
--   `options` **[object][72]** Options for the HOC as specified above.
+-   `varNames` **([string][71] \| [Array][72])** A variable name or array of variable names
+-   `options` **[object][74]** Options for the HOC as specified above.
 
 ### Examples
 
@@ -281,15 +296,15 @@ export default compose(
 )(TabBar)
 ```
 
-Returns **[Function][71]** A HOC that can be used to wrap a component.
+Returns **[Function][73]** A HOC that can be used to wrap a component.
 
 ## getSetPropTypes
 
-A function that returns propTypes for the [getSet][14] HOC.
+A function that returns propTypes for the [getSet][16] HOC.
 
 ### Parameters
 
--   `varNames` **([String][69] \| [Array][70])** A variable name or array of variable names.
+-   `varNames` **([String][71] \| [Array][72])** A variable name or array of variable names.
 
 ### Examples
 
@@ -305,7 +320,7 @@ export default compose(
 )(TabBar)
 ```
 
-Returns **[Object][72]** An object of corresponding propTypes.
+Returns **[Object][74]** An object of corresponding propTypes.
 
 ## modal
 
@@ -313,7 +328,7 @@ A function that returns a React HOC for creating modals.
 Styling for the default wrapper modal can be pulled from the `modal.css` file included in this library via your scss:
 `@import "~@launchpadlab/lp-hoc/lib/styles/modal.css";`
 
-Note: this HOC uses [`redux-modal`][73] under the hood. The reducer from `redux-modal` is exported for convenience as `modalReducer`.
+Note: this HOC uses [`redux-modal`][76] under the hood. The reducer from `redux-modal` is exported for convenience as `modalReducer`.
 
 The following functions are available as static properties on the wrapped component:
 
@@ -323,11 +338,11 @@ The following functions are available as static properties on the wrapped compon
 
 ### Parameters
 
--   `name` **[String][69]** The name of the modal.
--   `component` **([Function][71] \| [Object][72])?** A custom modal component to use to wrap your component. This wrapper is passed the following props: `{ warning, disableOutsideClick, show, handleHide, children }`. If `null` is provided, no wrapper will be used.
--   `warning` **[Boolean][74]** A boolean representing whether to add the `modal-warning` class to the surrounding `div`. (optional, default `false`)
--   `destroyOnHide` **[Boolean][74]** A boolean representing whether to destroy the modal state and unmount the modal after hide. (optional, default `true`)
--   `disableOutsideClick` **[Boolean][74]** A boolean representing whether clicking outside the modal div should hide the modal. (optional, default `false`)
+-   `name` **[String][71]** The name of the modal.
+-   `component` **([Function][73] \| [Object][74])?** A custom modal component to use to wrap your component. This wrapper is passed the following props: `{ warning, disableOutsideClick, show, handleHide, children }`. If `null` is provided, no wrapper will be used.
+-   `warning` **[Boolean][77]** A boolean representing whether to add the `modal-warning` class to the surrounding `div`. (optional, default `false`)
+-   `destroyOnHide` **[Boolean][77]** A boolean representing whether to destroy the modal state and unmount the modal after hide. (optional, default `true`)
+-   `disableOutsideClick` **[Boolean][77]** A boolean representing whether clicking outside the modal div should hide the modal. (optional, default `false`)
 
 ### Examples
 
@@ -365,7 +380,7 @@ export default compose(
 )(Layout)
 ```
 
-Returns **[Function][71]** A HOC that can be used to wrap a component.
+Returns **[Function][73]** A HOC that can be used to wrap a component.
 
 ## modifyProps
 
@@ -376,7 +391,7 @@ and should return an object that will be merged with those props.
 
 ### Parameters
 
--   `modFunction` **[Function][71]** A function that modifies the component's props.
+-   `modFunction` **[Function][73]** A function that modifies the component's props.
 
 ### Examples
 
@@ -417,16 +432,16 @@ export default compose(
 )(SaveableProfile)
 ```
 
-Returns **[Function][71]** A HOC that can be used to wrap a component.
+Returns **[Function][73]** A HOC that can be used to wrap a component.
 
 ## omitProps
 
 A function that returns a React HOC that omits some or all of a component's props.
-Uses the lodash [omit][75] function under the hood.
+Uses the lodash [omit][78] function under the hood.
 
 ### Parameters
 
--   `propName` **([String][69] \| [Array][70])** The name(s) of the prop(s) to be omitted. If none are provided, all of the props will be omitted.
+-   `propName` **([String][71] \| [Array][72])** The name(s) of the prop(s) to be omitted. If none are provided, all of the props will be omitted.
 
 ### Examples
 
@@ -444,7 +459,7 @@ function Parent () {
 // When parent is rendered, the <h1> will be empty.
 ```
 
-Returns **[Function][71]** A HOC that can be used to wrap a component.
+Returns **[Function][73]** A HOC that can be used to wrap a component.
 
 ## withClassName
 
@@ -454,7 +469,7 @@ This className will be extended by any additional classNames given to the compon
 
 ### Parameters
 
--   `defaultClass` **[String][69]** The default class to add to the component
+-   `defaultClass` **[String][71]** The default class to add to the component
 
 ### Examples
 
@@ -489,11 +504,11 @@ function Content () {
 A function that returns a React HOC to handle logic to be run during the `componentDidCatch` lifecycle event.
 NOTE: This HOC is only supported by React 16 or higher.
 
-See also: [onMount][35], [onUnmount][41], [onUpdate][44]
+See also: [onMount][37], [onUnmount][43], [onUpdate][46]
 
 ### Parameters
 
--   `onComponentDidCatch` **([Function][71] \| [String][69])** A function or a string reference to a function that will be executed with the component's props.
+-   `onComponentDidCatch` **([Function][73] \| [String][71])** A function or a string reference to a function that will be executed with the component's props.
 
 ### Examples
 
@@ -511,17 +526,17 @@ function MyComponent () {
  export default onError(onComponentDidCatch)(MyComponent)
 ```
 
-Returns **[Function][71]** A HOC that can be used to wrap a component.
+Returns **[Function][73]** A HOC that can be used to wrap a component.
 
 ## onMount
 
 A function that returns a React HOC to handle logic to be run during the `componentDidMount` lifecycle event.
 
-See also: [onError][32], [onUnmount][41], [onUpdate][44]
+See also: [onError][34], [onUnmount][43], [onUpdate][46]
 
 ### Parameters
 
--   `onComponentDidMount` **([Function][71] \| [String][69])** A function or a string reference to a function that will be executed with the component's props.
+-   `onComponentDidMount` **([Function][73] \| [String][71])** A function or a string reference to a function that will be executed with the component's props.
 
 ### Examples
 
@@ -539,7 +554,7 @@ function MyComponent () {
  export default onMount(componentDidMount)(MyComponent)
 ```
 
-Returns **[Function][71]** A HOC that can be used to wrap a component.
+Returns **[Function][73]** A HOC that can be used to wrap a component.
 
 ## onOutsideClick
 
@@ -547,7 +562,7 @@ A function that returns a React HOC to handle logic to be run when a click occur
 
 ### Parameters
 
--   `handler` **([Function][71] \| [String][69])** A function or a string reference to a function that will be executed with the component's props and the click event.
+-   `handler` **([Function][73] \| [String][71])** A function or a string reference to a function that will be executed with the component's props and the click event.
 
 ### Examples
 
@@ -565,17 +580,17 @@ function MyComponent () {
  export default onOutsideClick(handleOutsideClick)(MyComponent)
 ```
 
-Returns **[Function][71]** A HOC that can be used to wrap a component.
+Returns **[Function][73]** A HOC that can be used to wrap a component.
 
 ## onUnmount
 
 A function that returns a React HOC to handle logic to be run during the `componentWillUnmount` lifecycle event.
 
-See also: [onError][32], [onMount][35], [onUpdate][44]
+See also: [onError][34], [onMount][37], [onUpdate][46]
 
 ### Parameters
 
--   `onComponentWillUnmount` **([Function][71] \| [String][69])** A function or a string reference to a function that will be executed with the component's props.
+-   `onComponentWillUnmount` **([Function][73] \| [String][71])** A function or a string reference to a function that will be executed with the component's props.
 
 ### Examples
 
@@ -593,17 +608,17 @@ function MyComponent () {
  export default onUnmount(componentWillUnmount)(MyComponent)
 ```
 
-Returns **[Function][71]** A HOC that can be used to wrap a component.
+Returns **[Function][73]** A HOC that can be used to wrap a component.
 
 ## onUpdate
 
 A function that returns a React HOC to handle logic to be run during the `componentDidUpdate` lifecycle event.
 
-See also: [onError][32], [onMount][35], [onUnmount][41]
+See also: [onError][34], [onMount][37], [onUnmount][43]
 
 ### Parameters
 
--   `onComponentDidUpdate` **([Function][71] \| [String][69])** A function or a string reference to a function that will be passed the current props and the previous props.
+-   `onComponentDidUpdate` **([Function][73] \| [String][71])** A function or a string reference to a function that will be passed the current props and the previous props.
 
 ### Examples
 
@@ -621,7 +636,7 @@ function MyComponent () {
  export default onUpdate(componentDidUpdate)(MyComponent)
 ```
 
-Returns **[Function][71]** A HOC that can be used to wrap a component.
+Returns **[Function][73]** A HOC that can be used to wrap a component.
 
 ## sortable
 
@@ -636,7 +651,7 @@ The wrapped component will receive the following props:
 -   `setAscending`: a function for setting `ascending`
 -   `setDescending`: a function for setting `descending`
 -   `setSortPath`: a function for setting `sortPath`
--   `setSortFunc`: a function for setting a custom [comparison function][76] that will be used in `sort`
+-   `setSortFunc`: a function for setting a custom [comparison function][79] that will be used in `sort`
 
 `sortable` also exposes a `sortablePropTypes` object for these props.
 
@@ -658,7 +673,7 @@ The wrapped component may also receive these options as props.
 
 ### Parameters
 
--   `options` **[object][72]** Options for the HOC as specified above.
+-   `options` **[object][74]** Options for the HOC as specified above.
 
 ### Examples
 
@@ -695,11 +710,11 @@ export default compose(
 )(SortedPeopleList)
 ```
 
-Returns **[Function][71]** A HOC that can be used to wrap a component.
+Returns **[Function][73]** A HOC that can be used to wrap a component.
 
 ## sortablePropTypes
 
-PropTypes for the [sortable][47] HOC.
+PropTypes for the [sortable][49] HOC.
 
 ### Examples
 
@@ -726,7 +741,7 @@ Toggle also exposes a `togglePropTypes` function to automatically generate PropT
 
 ### Parameters
 
--   `toggleNames` **([String][69] \| [Array][70])** One or more toggle names. (optional, default `[]`)
+-   `toggleNames` **([String][71] \| [Array][72])** One or more toggle names. (optional, default `[]`)
 
 ### Examples
 
@@ -755,16 +770,16 @@ export default compose(
 )(ComponentWithTooltip)
 ```
 
-Returns **[Function][71]** A HOC that can be used to wrap a component.
+Returns **[Function][73]** A HOC that can be used to wrap a component.
 
 ## togglePropTypes
 
-A function that returns propTypes for the [toggle][52] HOC.
+A function that returns propTypes for the [toggle][54] HOC.
 For each toggle name given, the wrapped component will receive the following props:
 
 ### Parameters
 
--   `toggleNames` **([String][69] \| [Array][70])** One or more toggle names.
+-   `toggleNames` **([String][71] \| [Array][72])** One or more toggle names.
 
 ### Examples
 
@@ -780,7 +795,7 @@ export default compose(
 )(ComponentWithTooltip)
 ```
 
-Returns **[Object][72]** An object of corresponding propTypes.
+Returns **[Object][74]** An object of corresponding propTypes.
 
 ## waitFor
 
@@ -795,8 +810,8 @@ For the renderWhen param, the type can be one of the following:
 
 ### Parameters
 
--   `renderWhen` **([String][69] \| [Function][71] \| [Object][72])** A rule indicating when the wrapped component may render.
--   `LoadingComponent` **[Function][71]?** A component to render during the loading state, will be passed the current props. If not provided, `<div id="spinner" />` will be rendered. To hide this component, pass in `false` or `null`.
+-   `renderWhen` **([String][71] \| [Function][73] \| [Object][74])** A rule indicating when the wrapped component may render.
+-   `LoadingComponent` **[Function][73]?** A component to render during the loading state, will be passed the current props. If not provided, `<div id="spinner" />` will be rendered. To hide this component, pass in `false` or `null`.
 
 ### Examples
 
@@ -814,7 +829,7 @@ function MyComponent (name) {
  // Otherwise, the <Spinner /> component from `lp-components` will be rendered.
 ```
 
-Returns **[Function][71]** Returns a higher order component (HOC) to handle conditional logic for loading states.
+Returns **[Function][73]** Returns a higher order component (HOC) to handle conditional logic for loading states.
 
 ## connectQuery
 
@@ -824,11 +839,11 @@ parameter parsing OOTB.
 
 ### Parameters
 
--   `mappingConfig` **([Function][71] \| [String][69] \| [Array][70])** A function, string, or array of strings. String
+-   `mappingConfig` **([Function][73] \| [String][71] \| [Array][72])** A function, string, or array of strings. String
     arguments are interpreted as the names of props to pull from query params (note: if the camelized
     option is true, then the strings should be camelized accordingly).
--   `options` **[Object][72]?** Options for the HOC
-    -   `options.camelize` **[Boolean][74]** Option to camelize query parameter keys. This is true by default (optional, default `true`)
+-   `options` **[Object][74]?** Options for the HOC
+    -   `options.camelize` **[Boolean][77]** Option to camelize query parameter keys. This is true by default (optional, default `true`)
 
 ### Examples
 
@@ -854,7 +869,7 @@ export default compose(
 )(ResetPassword)
 ```
 
-Returns **[Function][71]** A HOC that can be used to wrap a component.
+Returns **[Function][73]** A HOC that can be used to wrap a component.
 
 ## connectParams
 
@@ -871,11 +886,11 @@ compose(
  connectParams,
 )
 
-For more information: [https://reacttraining.com/react-router/web/api/withRouter][77]
+For more information: [https://reacttraining.com/react-router/web/api/withRouter][80]
 
 ### Parameters
 
--   `mappingConfig` **([Function][71] \| [String][69] \| [Array][70])** A function, string, or array of strings. String
+-   `mappingConfig` **([Function][73] \| [String][71] \| [Array][72])** A function, string, or array of strings. String
     arguments are interpreted as the names of props to pull from matched params. A function argument
     will accept params and map them to props based on the object returned by this function 
     (see second example below).
@@ -946,7 +961,7 @@ export default compose(
 )(StudentShow)
 ```
 
-Returns **[Function][71]** A HOC that can be used to wrap a component.
+Returns **[Function][73]** A HOC that can be used to wrap a component.
 
 [1]: #adapttoreactrouter
 
@@ -968,136 +983,142 @@ Returns **[Function][71]** A HOC that can be used to wrap a component.
 
 [10]: #examples-3
 
-[11]: #deprecate
+[11]: #defaultcreatepublicid
 
 [12]: #parameters-2
 
-[13]: #examples-4
+[13]: #deprecate
 
-[14]: #getset
+[14]: #parameters-3
 
-[15]: #parameters-3
+[15]: #examples-4
 
-[16]: #examples-5
+[16]: #getset
 
-[17]: #getsetproptypes
+[17]: #parameters-4
 
-[18]: #parameters-4
+[18]: #examples-5
 
-[19]: #examples-6
+[19]: #getsetproptypes
 
-[20]: #modal
+[20]: #parameters-5
 
-[21]: #parameters-5
+[21]: #examples-6
 
-[22]: #examples-7
+[22]: #modal
 
-[23]: #modifyprops
+[23]: #parameters-6
 
-[24]: #parameters-6
+[24]: #examples-7
 
-[25]: #examples-8
+[25]: #modifyprops
 
-[26]: #omitprops
+[26]: #parameters-7
 
-[27]: #parameters-7
+[27]: #examples-8
 
-[28]: #examples-9
+[28]: #omitprops
 
-[29]: #withclassname
+[29]: #parameters-8
 
-[30]: #parameters-8
+[30]: #examples-9
 
-[31]: #examples-10
+[31]: #withclassname
 
-[32]: #onerror
+[32]: #parameters-9
 
-[33]: #parameters-9
+[33]: #examples-10
 
-[34]: #examples-11
+[34]: #onerror
 
-[35]: #onmount
+[35]: #parameters-10
 
-[36]: #parameters-10
+[36]: #examples-11
 
-[37]: #examples-12
+[37]: #onmount
 
-[38]: #onoutsideclick
+[38]: #parameters-11
 
-[39]: #parameters-11
+[39]: #examples-12
 
-[40]: #examples-13
+[40]: #onoutsideclick
 
-[41]: #onunmount
+[41]: #parameters-12
 
-[42]: #parameters-12
+[42]: #examples-13
 
-[43]: #examples-14
+[43]: #onunmount
 
-[44]: #onupdate
+[44]: #parameters-13
 
-[45]: #parameters-13
+[45]: #examples-14
 
-[46]: #examples-15
+[46]: #onupdate
 
-[47]: #sortable
+[47]: #parameters-14
 
-[48]: #parameters-14
+[48]: #examples-15
 
-[49]: #examples-16
+[49]: #sortable
 
-[50]: #sortableproptypes
+[50]: #parameters-15
 
-[51]: #examples-17
+[51]: #examples-16
 
-[52]: #toggle
+[52]: #sortableproptypes
 
-[53]: #parameters-15
+[53]: #examples-17
 
-[54]: #examples-18
+[54]: #toggle
 
-[55]: #toggleproptypes
+[55]: #parameters-16
 
-[56]: #parameters-16
+[56]: #examples-18
 
-[57]: #examples-19
+[57]: #toggleproptypes
 
-[58]: #waitfor
+[58]: #parameters-17
 
-[59]: #parameters-17
+[59]: #examples-19
 
-[60]: #examples-20
+[60]: #waitfor
 
-[61]: #connectquery
+[61]: #parameters-18
 
-[62]: #parameters-18
+[62]: #examples-20
 
-[63]: #examples-21
+[63]: #connectquery
 
-[64]: #connectparams
+[64]: #parameters-19
 
-[65]: #parameters-19
+[65]: #examples-21
 
-[66]: #examples-22
+[66]: #connectparams
 
-[67]: https://marmelab.com/blog/2016/09/20/custom-react-router-component.html
+[67]: #parameters-20
 
-[68]: https://github.com/shakacode/react_on_rails
+[68]: #examples-22
 
-[69]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[69]: https://marmelab.com/blog/2016/09/20/custom-react-router-component.html
 
-[70]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[70]: https://github.com/shakacode/react_on_rails
 
-[71]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[71]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[72]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[72]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[73]: https://github.com/yesmeck/redux-modal
+[73]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[74]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[74]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[75]: https://lodash.com/docs/4.17.4#omit
+[75]: https://support.cloudinary.com/hc/en-us/articles/115001317409--Legal-naming-conventions
 
-[76]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Description
+[76]: https://github.com/yesmeck/redux-modal
 
-[77]: https://reacttraining.com/react-router/web/api/withRouter
+[77]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+
+[78]: https://lodash.com/docs/4.17.4#omit
+
+[79]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Description
+
+[80]: https://reacttraining.com/react-router/web/api/withRouter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-hoc",
-  "version": "4.5.6",
+  "version": "4.5.7",
   "description": "React HOCs",
   "main": "lib/index.js",
   "module": "esm/index.js",

--- a/src/cloudinaryUploader.js
+++ b/src/cloudinaryUploader.js
@@ -74,7 +74,8 @@ const DEFAULT_REQUEST_OPTIONS = {
   mode: 'cors',
 }
 
-export const FORBIDDEN_PATTERN = /[?&#\\%<>]/gi
+// Test for all forbidden characters (defined by Cloudinary) and spaces
+const FILE_NAME_PATTERN = /[\s?&#\\%<>]/gi
 
 /**
  * The default public id creator returns the sanitized name of the file by
@@ -85,13 +86,14 @@ export const FORBIDDEN_PATTERN = /[?&#\\%<>]/gi
  * Source: https://support.cloudinary.com/hc/en-us/articles/115001317409--Legal-naming-conventions
  */
 function defaultCreatePublicId (file) {
-  const decodedFileName = decodeFileName(file.name)
+  const decodedFileName = decodeFileName(file.name || 'file_upload_' + Date.now())
   return sanitizeFileName(decodedFileName)
 }
 
-// Attempts to decode html escaped characters. If this fails, strips characters
-// causing a malformed URI and tries again. If all else fails, returns the original name
-function decodeFileName (name='') {
+// Attempts to decode html escaped characters. If this fails, attempts to strip
+// percentages not acting as valid html escaping and tries again. If all else
+// fails, returns the original name.
+function decodeFileName (name) {
   try {
     try {
       return decodeURIComponent(name)
@@ -104,10 +106,9 @@ function decodeFileName (name='') {
 }
 
 // Replaces forbidden characters with '_' and removes duplicate underscores
-function sanitizeFileName (name='') {
-  const validFileName = name.trim().replace(FORBIDDEN_PATTERN, '_')
-  const validFileNameWithoutSpaces = validFileName.replace(/\s+/gi, '_')
-  return validFileNameWithoutSpaces.replace(/_+/gi, '_')
+function sanitizeFileName (name) {
+  const validFileName = name.trim().replace(FILE_NAME_PATTERN, '_')
+  return validFileName.replace(/_+/gi, '_')
 }
 
 // Removes file extension from file name if asset is an image or pdf

--- a/src/cloudinaryUploader.js
+++ b/src/cloudinaryUploader.js
@@ -86,8 +86,14 @@ const FILE_NAME_PATTERN = /[\s?&#\\%<>]/gi
  * Source: https://support.cloudinary.com/hc/en-us/articles/115001317409--Legal-naming-conventions
  */
 function defaultCreatePublicId (file) {
-  const decodedFileName = decodeFileName(file.name || 'file_upload_' + Date.now())
+  const fileName = getFileName(file)
+  const decodedFileName = decodeFileName(fileName)
   return sanitizeFileName(decodedFileName)
+}
+
+function getFileName (file) {
+  if (file.name) return file.name
+  return 'file_upload_' + Date.now()
 }
 
 // Attempts to decode html escaped characters. If this fails, attempts to strip

--- a/test/cloudinary-uploader.test.js
+++ b/test/cloudinary-uploader.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import cloudinaryUploader, { FORBIDDEN_PATTERN } from '../src/cloudinaryUploader'
+import cloudinaryUploader from '../src/cloudinaryUploader'
 
 const props = {
   bucket: 'test-bucket',
@@ -123,6 +123,7 @@ test('cloudinaryUploader adds extension to `publicId` of raw files', () => {
 })
 
 test('cloudinaryUploader removes invalid characters from the default `publicId`', () => {
+  const FORBIDDEN_PATTERN = /[\s?&#\\%<>]/gi
   const illegallyNamedFile = { name: 'Final \\ Master %20 Schedule? #S1&S2 <100%> & finished.pdf', type: 'application/pdf' }
   const Wrapped = () => <h1>Howdy</h1>
   const Wrapper = cloudinaryUploader({ ...props })(Wrapped)
@@ -175,6 +176,25 @@ test('cloudinaryUploader trims spaces from the start of the default `publicId`',
     component.update()
     const responseJson = JSON.parse(response.body)
     expect(responseJson.public_id).toEqual('Example')
+  })
+})
+
+test('cloudinaryUploader defaults file name if not provided when creating the default `publicId`', () => {
+  const fileWithNoName = { name: '', type: 'application/pdf' }
+  const Wrapped = () => <h1>Howdy</h1>
+  const Wrapper = cloudinaryUploader({ ...props })(Wrapped)
+  const component = shallow(<Wrapper />)
+  const { upload } = component.props()
+  
+  const spy = jest.spyOn(global.Date, 'now')
+  
+  return upload(fileData, fileWithNoName).then(response => {
+    component.update()
+    const responseJson = JSON.parse(response.body)
+    expect(responseJson.public_id).toContain('file_upload')
+    expect(spy).toHaveBeenCalled()
+    
+    spy.mockRestore()
   })
 })
 

--- a/test/cloudinary-uploader.test.js
+++ b/test/cloudinary-uploader.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { cloudinaryUploader } from '../src/'
+import cloudinaryUploader, { FORBIDDEN_PATTERN } from '../src/cloudinaryUploader'
 
 const props = {
   bucket: 'test-bucket',
@@ -122,10 +122,8 @@ test('cloudinaryUploader adds extension to `publicId` of raw files', () => {
   })
 })
 
-test('cloudinaryUploader adds html escaping to the default `publicId`', () => {
-  const illegallyNamedFile = { name: 'Final \\ Master Schedule? #S1&S2 <100%>.pdf', type: 'application/pdf' }
-  const forbiddenPattern = /[?&#\\<>]/
-  
+test('cloudinaryUploader removes invalid characters from the default `publicId`', () => {
+  const illegallyNamedFile = { name: 'Final \\ Master %20 Schedule? #S1&S2 <100%> & finished.pdf', type: 'application/pdf' }
   const Wrapped = () => <h1>Howdy</h1>
   const Wrapper = cloudinaryUploader({ ...props })(Wrapped)
   const component = shallow(<Wrapper />)
@@ -134,7 +132,49 @@ test('cloudinaryUploader adds html escaping to the default `publicId`', () => {
   return upload(fileData, illegallyNamedFile).then(response => {
     component.update()
     const responseJson = JSON.parse(response.body)
-    expect(responseJson.public_id).not.toMatch(forbiddenPattern)
+    expect(responseJson.public_id).not.toMatch(FORBIDDEN_PATTERN)
+  })
+})
+
+test('cloudinaryUploader removes html escaped characters from the default `publicId`', () => {
+  const illegallyNamedFile = { name: 'SY%20S1%26S2.pdf', type: 'application/pdf' }
+  const Wrapped = () => <h1>Howdy</h1>
+  const Wrapper = cloudinaryUploader({ ...props })(Wrapped)
+  const component = shallow(<Wrapper />)
+  const { upload } = component.props()
+  
+  return upload(fileData, illegallyNamedFile).then(response => {
+    component.update()
+    const responseJson = JSON.parse(response.body)
+    expect(responseJson.public_id).toEqual('SY_S1_S2')
+  })
+})
+
+test('cloudinaryUploader replaces spaces and removes superfluous underscores from the default `publicId`', () => {
+  const illegallyNamedFile = { name: '     SY     S1___S2.pdf', type: 'application/pdf' }
+  const Wrapped = () => <h1>Howdy</h1>
+  const Wrapper = cloudinaryUploader({ ...props })(Wrapped)
+  const component = shallow(<Wrapper />)
+  const { upload } = component.props()
+  
+  return upload(fileData, illegallyNamedFile).then(response => {
+    component.update()
+    const responseJson = JSON.parse(response.body)
+    expect(responseJson.public_id).toEqual('SY_S1_S2')
+  })
+})
+
+test('cloudinaryUploader trims spaces from the start of the default `publicId`', () => {
+  const illegallyNamedFile = { name: '     Example.pdf', type: 'application/pdf' }
+  const Wrapped = () => <h1>Howdy</h1>
+  const Wrapper = cloudinaryUploader({ ...props })(Wrapped)
+  const component = shallow(<Wrapper />)
+  const { upload } = component.props()
+  
+  return upload(fileData, illegallyNamedFile).then(response => {
+    component.update()
+    const responseJson = JSON.parse(response.body)
+    expect(responseJson.public_id).toEqual('Example')
   })
 })
 


### PR DESCRIPTION
Resolves #123 

**Summary:**
- Decodes file name that has escaped html characters
  - Accounts for names that cause a malformed URI exception (e.g., a `%` that is not followed by at least one decimal)
- Sanitizes the file name
  - Trims file name
  - Replaces invalid characters (according to Cloudinary's docs) with an underscore
  - Replaces spaces with an underscore (Cloudinary would do this anyways)
  - Replaces superfluous underscores with a single underscore (e.g., `file____name__2.pdf` -> `file_name_2.pdf`)

Trimming, replacing spaces, and replacing superfluous underscores makes this a more opinionated fix. However, I think that's ok because it only applies to the default handler for creating a public id, which can be easily be overridden by passing in a `cloudinaryPublicId` or `createPublicId` prop.